### PR TITLE
chore: Sync with rhiza

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ _book
 _pdoc
 _marimushka
 _benchmarks
+_jupyter
 
 # temp file used by Junie
 .output.txt

--- a/.rhiza/history
+++ b/.rhiza/history
@@ -50,7 +50,6 @@ book/README.md
 book/book.mk
 book/marimo/README.md
 book/marimo/marimo.mk
-book/marimo/notebooks/dummy.py
 book/marimo/notebooks/rhiza.py
 book/minibook-templates/custom.html.jinja2
 presentation/README.md
@@ -63,6 +62,7 @@ tests/test_rhiza/benchmarks/.gitignore
 tests/test_rhiza/benchmarks/README.md
 tests/test_rhiza/benchmarks/analyze_benchmarks.py
 tests/test_rhiza/conftest.py
+tests/test_rhiza/test_book.py
 tests/test_rhiza/test_check_workflow_names.py
 tests/test_rhiza/test_docstrings.py
 tests/test_rhiza/test_git_repo_fixture.py

--- a/book/book.mk
+++ b/book/book.mk
@@ -7,6 +7,17 @@
 # Declare phony targets (they don't produce files)
 .PHONY: docs marimushka book
 
+# Define a default no-op marimushka target that will be used
+# when book/marimo/marimo.mk doesn't exist or doesn't define marimushka
+marimushka:: install-uv
+	@if [ ! -d "book/marimo" ]; then \
+	  printf "${BLUE}[INFO] No Marimo directory found, creating placeholder${RESET}\n"; \
+	  mkdir -p "${MARIMUSHKA_OUTPUT}"; \
+	  printf '%s\n' '<html><head><title>Marimo Notebooks</title></head>' \
+	    '<body><h1>Marimo Notebooks</h1><p>No notebooks found.</p></body></html>' \
+	    > "${MARIMUSHKA_OUTPUT}/index.html"; \
+	fi
+
 # Default output directory for Marimushka (HTML exports of notebooks)
 MARIMUSHKA_OUTPUT ?= _marimushka
 

--- a/book/marimo/marimo.mk
+++ b/book/marimo/marimo.mk
@@ -42,7 +42,7 @@ marimo: install ## fire up Marimo server
 # 1. Detects notebooks in the MARIMO_FOLDER.
 # 2. Converts them using 'marimushka export'.
 # 3. Generates a placeholder index.html if no notebooks are found.
-marimushka: install-uv ## export Marimo notebooks to HTML
+marimushka:: install-uv ## export Marimo notebooks to HTML
 	# Clean up previous marimushka output
 	rm -rf "${MARIMUSHKA_OUTPUT}";
 

--- a/tests/test_rhiza/conftest.py
+++ b/tests/test_rhiza/conftest.py
@@ -237,9 +237,11 @@ def git_repo(root, tmp_path, monkeypatch):
     shutil.copy(root / ".rhiza" / "scripts" / "release.sh", script_dir / "release.sh")
     shutil.copy(root / ".rhiza" / "rhiza.mk", local_dir / ".rhiza" / "rhiza.mk")
     shutil.copy(root / "Makefile", local_dir / "Makefile")
-    os.makedirs(local_dir / "book" / "marimo", exist_ok=True)
-    shutil.copy(root / "book" / "book.mk", local_dir / "book" / "book.mk")
-    shutil.copy(root / "book" / "marimo" / "marimo.mk", local_dir / "book" / "marimo" / "marimo.mk")
+
+    book_src = root / "book"
+    book_dst = local_dir / "book"
+    if book_src.is_dir():
+        shutil.copytree(book_src, book_dst, dirs_exist_ok=True)
 
     (script_dir / "release.sh").chmod(0o755)
 

--- a/tests/test_rhiza/test_book.py
+++ b/tests/test_rhiza/test_book.py
@@ -1,0 +1,66 @@
+"""Tests for book-related Makefile targets and their resilience."""
+
+import shutil
+import subprocess
+
+import pytest
+
+MAKE = shutil.which("make") or "/usr/bin/make"
+
+
+def test_no_book_folder(git_repo):
+    """Test that make targets fail gracefully when book folder is missing."""
+    shutil.rmtree(git_repo / "book")
+    assert not (git_repo / "book").exists()
+
+    for target in ["book", "docs", "marimushka"]:
+        # test resilience
+        result = subprocess.run([MAKE, target], cwd=git_repo, capture_output=True, text=True)
+
+        assert result.returncode != 0
+        assert "no rule to make target" in result.stderr.lower()
+
+
+def test_book_folder_but_no_mk(git_repo):
+    """Test behavior when book folder exists but book.mk is missing."""
+    # ensure book folder exists but has no Makefile
+    shutil.rmtree(git_repo / "book")
+    # create an empty book folder. Make treats an existing directory as an “up-to-date” target.
+    (git_repo / "book").mkdir()
+
+    # assert the book folder exists
+    assert (git_repo / "book").exists()
+    # assert the book.mk file does not exist
+    assert not (git_repo / "book" / "book.mk").exists()
+    # assert the git_repo / "book" folder is empty
+    assert not list((git_repo / "book").iterdir())
+
+    # test resilience
+    result = subprocess.run([MAKE, "book"], cwd=git_repo, capture_output=True, text=True)
+
+    assert result.returncode == 0
+    assert "nothing to be done" in result.stdout.lower()
+
+    for target in ["docs", "marimushka"]:
+        # test resilience
+        result = subprocess.run([MAKE, target], cwd=git_repo, capture_output=True, text=True)
+
+        assert result.returncode != 0
+        assert "no rule to make target" in result.stderr.lower()
+
+
+def test_book_folder(git_repo):
+    """Test that book.mk defines the expected phony targets."""
+    # if file book/book.mk exists, make should run successfully
+    if not (git_repo / "book" / "book.mk").exists():
+        pytest.skip("book.mk not found, skipping test")
+
+    makefile = git_repo / "book" / "book.mk"
+    content = makefile.read_text()
+
+    # get the list of phony targets from the Makefile
+    phony_targets = [line.strip() for line in content.splitlines() if line.startswith(".PHONY:")]
+    targets = set(phony_targets[0].split(":")[1].strip().split())
+    assert {"book", "docs", "marimushka"} == targets, (
+        f"Expected phony targets to include book, docs, and marimushka, got {targets}"
+    )

--- a/tests/test_rhiza/test_makefile.py
+++ b/tests/test_rhiza/test_makefile.py
@@ -140,7 +140,7 @@ class TestMakefile:
         assert "Usage:" in out
         assert "Targets:" in out
         # ensure a few known targets appear in the help index
-        for target in ["install", "fmt", "deptry", "test", "book", "help"]:
+        for target in ["install", "fmt", "deptry", "test", "help"]:
             assert target in out
 
     def test_help_target(self, logger):
@@ -221,8 +221,6 @@ class TestMakefile:
         # Expect key steps
         assert "mkdir -p _tests/html-coverage _tests/html-report" in out
         # Check for uv command with the configured path
-        # expected_uv = f"{expected_uv_install_dir}/uv"
-        # assert f"{expected_uv} run pytest" in out
 
     def test_test_target_without_source_folder(self, logger, tmp_path):
         """Test target should run without coverage when SOURCE_FOLDER doesn't exist."""
@@ -243,31 +241,6 @@ class TestMakefile:
         # Should still run pytest but without coverage flags
         assert "pytest tests" in out
         assert "--html=_tests/html-report/report.html" in out
-
-    def test_book_target_dry_run(self, logger):
-        """Book target should run inline commands to assemble the book."""
-        proc = run_make(logger, ["book"])
-        out = proc.stdout
-        # Expect directory creation, links.json generation and minibook to be invoked
-        assert "mkdir -p _book" in out
-        assert "links.json" in out
-        assert "minibook" in out
-
-    @pytest.mark.parametrize("target", ["book", "docs", "marimushka"])
-    def test_book_related_targets_fallback_without_book_folder(self, logger, tmp_path, target):
-        """Book-related targets should show a warning when book folder is missing."""
-        # Remove the book folder to test fallback
-        book_folder = tmp_path / "book"
-        if book_folder.exists():
-            shutil.rmtree(book_folder)
-
-        proc = run_make(logger, [target], check=False, dry_run=False)
-        out = strip_ansi(proc.stdout)
-        # out = strip_ansi(proc.stderr)
-        assert out == ""
-        # assert out == f"[WARN] Book folder not found. Target '{target}' is not available.\n"
-
-        assert proc.returncode == 2  # Fails
 
     def test_python_version_defaults_to_3_13_if_missing(self, logger, tmp_path):
         """`PYTHON_VERSION` should default to `3.13` if .python-version is missing."""
@@ -334,7 +307,7 @@ class TestMakefileRootFixture:
             if split_path.exists():
                 content += "\n" + split_path.read_text()
 
-        expected_targets = ["install", "fmt", "test", "deptry", "book", "help"]
+        expected_targets = ["install", "fmt", "test", "deptry", "help"]
         for target in expected_targets:
             assert f"{target}:" in content or f".PHONY: {target}" in content
 

--- a/tests/test_rhiza/test_marimushka_target.py
+++ b/tests/test_rhiza/test_marimushka_target.py
@@ -10,6 +10,8 @@ import os
 import shutil
 import subprocess
 
+import pytest
+
 # Get shell path and make command once at module level
 SHELL = shutil.which("sh") or "/bin/sh"
 MAKE = shutil.which("make") or "/usr/bin/make"
@@ -17,6 +19,10 @@ MAKE = shutil.which("make") or "/usr/bin/make"
 
 def test_marimushka_target_success(git_repo):
     """Test successful execution of the marimushka Makefile target."""
+    # only run this test if the marimo folder is present
+    if not (git_repo / "book" / "marimo").exists():
+        pytest.skip("marimo folder not found, skipping test")
+
     # Setup directories in the git repo
     marimo_folder = git_repo / "book" / "marimo" / "notebooks"
     marimo_folder.mkdir(parents=True, exist_ok=True)
@@ -61,21 +67,18 @@ def test_marimushka_target_success(git_repo):
     assert (output_folder / "notebooks" / "notebook.html").exists()
 
 
-def test_marimushka_missing_folder(git_repo):
-    """Test marimushka target behavior when MARIMO_FOLDER is missing."""
-    env = os.environ.copy()
-    env["MARIMO_FOLDER"] = "missing"
-
-    result = subprocess.run([MAKE, "marimushka"], env=env, cwd=git_repo, capture_output=True, text=True)
-
-    assert result.returncode == 0
-    assert "does not exist" in result.stdout
-
-
 def test_marimushka_no_python_files(git_repo):
     """Test marimushka target behavior when MARIMO_FOLDER has no python files."""
+    if not (git_repo / "book" / "marimo").exists():
+        pytest.skip("marimo folder not found, skipping test")
+
     marimo_folder = git_repo / "book" / "marimo" / "notebooks"
     marimo_folder.mkdir(parents=True, exist_ok=True)
+
+    # Delete all .py files in the marimo folder
+    for file in marimo_folder.glob("*.py"):
+        file.unlink()
+
     # No .py files created
 
     output_folder = git_repo / "_marimushka"
@@ -87,6 +90,4 @@ def test_marimushka_no_python_files(git_repo):
     result = subprocess.run([MAKE, "marimushka"], env=env, cwd=git_repo, capture_output=True, text=True)
 
     assert result.returncode == 0
-    assert "No Python files found" in result.stdout
     assert (output_folder / "index.html").exists()
-    assert "No notebooks found" in (output_folder / "index.html").read_text()


### PR DESCRIPTION
## 🔄 Template Synchronization

This PR synchronizes the repository with the [jebel-quant/rhiza](https://github.com/jebel-quant/rhiza) template.

### 📊 Change Summary

- **1** files added
- **7** files modified
- **0** files deleted

### 📁 Changes by Category

#### Configuration Files

<details>
<summary>Modified (1)</summary>

- 📝 `.gitignore`

</details>

#### Documentation

<details>
<summary>Modified (2)</summary>

- 📝 `book/book.mk`
- 📝 `book/marimo/marimo.mk`

</details>

#### Rhiza Configuration

<details>
<summary>Modified (1)</summary>

- 📝 `.rhiza/history`

</details>

#### Tests

<details>
<summary>Added (1)</summary>

- ✅ `tests/test_rhiza/test_book.py`

</details>

<details>
<summary>Modified (3)</summary>

- 📝 `tests/test_rhiza/conftest.py`
- 📝 `tests/test_rhiza/test_makefile.py`
- 📝 `tests/test_rhiza/test_marimushka_target.py`

</details>

---

**🤖 Generated by [rhiza](https://github.com/jebel-quant/rhiza-cli)**

- Template: `jebel-quant/rhiza@main`
- Last sync: 2026-01-24T11:34:04+04:00
- Sync date: 2026-01-26T00:55:58.935513+00:00